### PR TITLE
feat: custom row

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ const data = [
   data={data}
   start="2020-04-04"
   end="2023-05-19"
+  daysOfTheWeek={['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']}
   textColor="#1F2328"
   startsOnSunday={true}
   includeBoundary={true}
@@ -101,6 +102,7 @@ const data = [
 
 - **`start`**: Optional. The starting date for the calendar to start, defaults to current year's January 1st(`YYYY-MM-DD` format).
 - **`end`**: Optional. The ending date for the calendar to end, defaults to current year's December 31st(`YYYY-MM-DD` format).
+- **`daysOfTheWeek`**: Optional. The days of the week, which will be the head column of each row. The array should start from Sunday so that you can use with `startsOnSunday` option correctly. Defaults to `['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']`.
 - **`textColor`**: Optional. The color of indexes. String color code format, defaults to `#1F2328`.
 - **`startsOnSunday`**: Optional. Whether to start the calendar on Sunday or not, defaults to `true`. If set to false, calendar will start on Monday.
 - **`includeBoundary`**: Optional. Whether to include the boundary cells in the starting or ending date column, defaults to `true`.

--- a/README.md
+++ b/README.md
@@ -30,20 +30,13 @@ import { ContributionCalendar } from 'react-contribution-calendar'
 
 const data = [
   {
-    '2020-04-20': {
-      level: 2,
-    }
+    '2020-04-20': { level: 2 }
   },
   {
-    '2023-07-08': {
-      level: 1,
-    },
+    '2023-07-08': { level: 1 },
   },
   {
-    '2023-07-09': {
-      level: 4,
-      data: {},
-    },
+    '2023-07-09': { level: 4, data: {} },
   },
   {
     '2023-03-31': {

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -9,6 +9,7 @@ interface TableProps {
   data?: InputData[]
   start?: string
   end?: string
+  daysOfTheWeek?: string[]
   textColor?: string
   startsOnSunday?: boolean
   includeBoundary?: boolean
@@ -24,6 +25,7 @@ export default function Table({
   data = [],
   start = getDateString(getCurrentYear(), 0, 1),
   end = getDateString(getCurrentYear(), 11, 31),
+  daysOfTheWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
   textColor = '#1f2328',
   startsOnSunday = true,
   includeBoundary = true,
@@ -45,6 +47,7 @@ export default function Table({
             data={data}
             start={start}
             end={end}
+            daysOfTheWeek={daysOfTheWeek}
             textColor={textColor}
             startsOnSunday={startsOnSunday}
             includeBoundary={includeBoundary}

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -2,6 +2,7 @@ import { CSSProperties } from 'react'
 import TableHead from '../TableHead'
 import TableBody from '../TableBody'
 import { getCurrentYear, getDateString } from '../../utils'
+import { customError, ERROR } from '../../exceptions'
 import './index.css'
 import Description from '../Description'
 
@@ -37,6 +38,10 @@ export default function Table({
   style,
 }: TableProps) {
   const padding = `0 ${cx + 70}px 0 ${cx + 10}px`
+
+  if (daysOfTheWeek.length !== 7) {
+    throw customError(ERROR.Number, 'The length of the `daysOfTheWeek` should be exact 7.')
+  }
 
   return (
     <div className="container" style={style}>

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -34,7 +34,7 @@ export default function Table({
   cy = 10,
   cr = 2,
   theme = 'grass',
-  onCellClick = () => {},
+  onCellClick = (_, data) => console.log(data),
   style,
 }: TableProps) {
   const padding = `0 ${cx + 70}px 0 ${cx + 10}px`

--- a/src/components/TableBody/index.tsx
+++ b/src/components/TableBody/index.tsx
@@ -15,6 +15,7 @@ interface TableBodyProps {
   data: InputData[]
   start: string
   end: string
+  daysOfTheWeek: string[]
   textColor: string
   startsOnSunday: boolean
   includeBoundary: boolean
@@ -29,6 +30,7 @@ export default function TableBody({
   data,
   start,
   end,
+  daysOfTheWeek,
   textColor,
   startsOnSunday,
   includeBoundary,
@@ -48,8 +50,12 @@ export default function TableBody({
   const { colSpans } = getMonthsAndColSpans(start, end, dayArray, startsOnSunday)
 
   const DATES = startsOnSunday
-    ? ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
-    : ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+    ? daysOfTheWeek
+    : (() => {
+        const tempDaysOfTheWeek = [...daysOfTheWeek]
+        tempDaysOfTheWeek.push(tempDaysOfTheWeek.shift() || '')
+        return tempDaysOfTheWeek
+      })()
 
   const themeProps = createTheme(theme)
   const parsedData = parseInputData(data)

--- a/src/components/TableHead/index.css
+++ b/src/components/TableHead/index.css
@@ -5,3 +5,10 @@ thead {
   top: 0;
   width: fit-content;
 }
+
+.day-of-the-week {
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -webkit-user-drag: none;
+}

--- a/src/components/TableHead/index.tsx
+++ b/src/components/TableHead/index.tsx
@@ -20,7 +20,7 @@ export default function TableHead({ start, end, textColor, startsOnSunday, cy }:
   return (
     <thead>
       <tr>
-        <Label textColor={textColor} style={{ fontSize: cy }} colSpan={1}>
+        <Label className='day-of-the-week' textColor={textColor} style={{ fontSize: cy }} colSpan={1}>
           &nbsp;
         </Label>
         {months.map((month, index) => {

--- a/src/exceptions/index.ts
+++ b/src/exceptions/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Creates a named custom error with message.
+ * @param {string} name - The name of the error.
+ * @param {string} message - The error message.
+ * @returns {Error} Error instance.
+ */
+export const customError = (name: string, message: string): Error => {
+  const error = new Error(message)
+  error.name = name
+  return error
+}
+
+export enum ERROR {
+  Number = 'Number Error',
+  String = 'String Error',
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import './index.css'
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ContributionCalendar
+      daysOfTheWeek={['', 'Mon', '', 'Wed', '', 'Fri', '']}
       textColor="#1f2328"
       startsOnSunday={true}
       includeBoundary={true}

--- a/src/types/react-contribution-calendar.d.ts
+++ b/src/types/react-contribution-calendar.d.ts
@@ -135,8 +135,8 @@ declare module 'react-contribution-calendar' {
      */
     theme?: string | ThemeProps
     /**
-     * Click event handler for table cells. This takes `cellData` as optional value
-     * and returns callback function.
+     * Click event handler for table cells. This takes `data` as optional value 
+     * of each cell and returns callback function.
      * @example
      * ```tsx
      * <ContributionCalendar onCellClick={(e, data) => console.log(data)} />

--- a/src/types/react-contribution-calendar.d.ts
+++ b/src/types/react-contribution-calendar.d.ts
@@ -11,6 +11,16 @@ declare module 'react-contribution-calendar' {
    * Returns an object of ThemeProps which could be used as theme attribute of
    * ContributionCalendarProps.
    * @param {ThemeProps} themeProps - Theme color properties from level 0 to 4.
+   * @example
+   * ```tsx
+   * const customTheme = createTheme({
+      level0: '#ebedf0',
+      level1: '#9be9a8',
+      level2: '#40c463',
+      level3: '#30a14e',
+      level4: '#216e39',
+   * })
+   * ```
    */
   export const createTheme: (themeProps: ThemeProps) => ThemeProps
 
@@ -20,54 +30,125 @@ declare module 'react-contribution-calendar' {
   export interface ContributionCalendarProps {
     /**
      * List of items in the data, defaults to an empty list `[]`.
+     * @example
+     * ```tsx
+     * const data = [
+     *   {
+     *     "2023-07-08": { "level": 2, "data": {} }
+     *   },
+     *   {
+     *     "2023-07-09": { "level": 1, "data": {} }
+     *   },
+     *   ...
+     * ]
+     *
+     * <ContributionCalendar data={data} />
+     * ```
      */
     data?: InputData[]
     /**
      * The starting date of calendar, defaults to 1st January of current year.
-     * To set `start` date, `end` date should be provided as well.
+     * `start` date must be earlier than `end` date.
+     * @example
+     * ```tsx
+     * <ContributionCalendar start="2023-04-04" />
+     * ```
      */
     start?: string
     /**
      * The ending date of calendar, defaults to 31st December of current year.
-     * To set `end` date, `start` date should be provided as well.
+     * `start` date must be earlier than `end` date.
+     * @example
+     * ```tsx
+     * <ContributionCalendar end="2023-05-19" />
+     * ```
      */
     end?: string
     /**
+     * The days of the week, defaults to `['Sun', 'Mon', ... 'Sat']`. The day of the
+     * week should start from Sunday regardless of the `startsOnSunday` option.
+     * The length of the array must be exact `7`.
+     * @example
+     * ```tsx
+     * const daysOfTheWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+     *
+     * <ContributionCalendar daysOfTheWeek={daysOfTheWeek} />
+     * ```
+     */
+    daysOfTheWeek?: string[]
+    /**
      * The text color of calendar indexes for months and dates, defaults to `#1F2328`.
+     * @example
+     * ```tsx
+     * <ContributionCalendar textColor="#000" />
+     * ```
      */
     textColor?: string
     /**
      * Whether to set calendar start on Sunday or not, defaults to `true`.
      * If set to false, the week will start on Monday.
+     * @example
+     * ```tsx
+     * <ContributionCalendar startsOnSunday={true} />
+     * ```
      */
     startsOnSunday?: boolean
     /**
      * Whether to include the boundary column or not, defaults to `true`.
+     * @example
+     * ```tsx
+     * <ContributionCalendar includeBoundary={true} />
+     * ```
      */
     includeBoundary?: boolean
     /**
      * The size of width of each cell, defaults to `10`px.
+     * @example
+     * ```tsx
+     * <ContributionCalendar cx={10} />
+     * ```
      */
     cx?: number
     /**
      * The size of height of each cell, defaults to `10`px.
+     * @example
+     * ```tsx
+     * <ContributionCalendar cy={10} />
+     * ```
      */
     cy?: number
     /**
      * The border radius of each cell, defaults to `2`px.
+     * @example
+     * ```tsx
+     * <ContributionCalendar cr={2} />
+     * ```
      */
     cr?: number
     /**
      * The name of theme for the ContributionCalendar, defaults to `grass`. Also
      * `ThemeProps` could be added directly i.e. when trying to use custom theme.
+     * @example
+     * ```tsx
+     * <ContributionCalendar theme="grass" />
+     * ```
      */
     theme?: string | ThemeProps
     /**
-     * Click event handler for table cells. This takes `cellData` as optional value.
+     * Click event handler for table cells. This takes `cellData` as optional value
+     * and returns callback function.
+     * @example
+     * ```tsx
+     * <ContributionCalendar onCellClick={(e, data) => console.log(data)} />
+     * ```
      */
     onCellClick?: MouseEventHandler
     /**
      * Root styles for the ContributionCalendar.
+     * @example
+     * ```tsx
+     * <ContributionCalendar style={{ padding: '4px' }} />
+     * ```
      */
     style?: CSSProperties
   }


### PR DESCRIPTION
## What's been added

- Custom head of the row indexes
- Exception instance

```tsx
/**
 * The days of the week, defaults to `['Sun', 'Mon', ... 'Sat']`. The day of the
 * week should start from Sunday regardless of the `startsOnSunday` option.
 * The length of the array must be exact `7`.
 * @example
 * ```tsx
 * const daysOfTheWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 *
 * <ContributionCalendar daysOfTheWeek={daysOfTheWeek} />
 * ```
 */
daysOfTheWeek?: string[]
```

<br />    

### Example 1

```tsx
<ContributionCalendar daysOfTheWeek={['', 'Mon', '', 'Wed', '', 'Fri', '']} />
```

<img width="764" alt="Screenshot 2023-08-28 at 2 39 07 PM" src="https://github.com/encaffeine/react-contribution-calendar/assets/63793178/949612a4-091d-4117-804c-b1f48f138164">


<br />   

### Example 2

```tsx
<ContributionCalendar daysOfTheWeek={['a', 'b', 'c', 'd', 'e', 'f', 'g']} />
```

<img width="764" alt="Screenshot 2023-08-28 at 2 39 28 PM" src="https://github.com/encaffeine/react-contribution-calendar/assets/63793178/dd862819-09ba-4608-a906-084f48b6fb78">
